### PR TITLE
fix: :pencil2: typos found from `typos` check

### DIFF
--- a/documents/data-flow.qmd
+++ b/documents/data-flow.qmd
@@ -21,14 +21,14 @@ Red@{shape: cyl, label: "<b>REDCap db</b><br> database, main purpose is to colla
 Genome@{shape: lin-cyl, label: "<b>GenomeDK</b><br> HPC facility where the processed data will be stored. "}
 
 Forms@{shape: proc, label: "<b>Forms in REDCap</b><br> multiple forms and questionnaires for both healthcare staff and participants"}
-Mons@{shape: proc, label: "<b>Liva</b><br> main study app which allows users to enter information about meals, activity, ect"}
+Mons@{shape: proc, label: "<b>Liva</b><br> main study app which allows users to enter information about meals, activity, etc"}
 MyF@{shape: proc, label: "<b>MyFood24</b><br> app which helps users to register food ...."}
 iMo@{shape: proc, label: "<b>iMotions Food Preference</b><br> tracks eye movement of participants when looking at pictures of food."}
 Sen@{shape: proc, label: "<b>SENS</b><br> activity monitor, placed on the study participant and then collected and read in the clinic."}
 Lib@{shape: proc, label: "<b>Libre</b><br> Blinded CGM sensor from Abbott which participants will be wearing. Will be read in the clinic."}
 Watch@{shape: proc, label: "<b>Watch</b><br> smart watch which will connect to the Liva app."}
 Scales@{shape: proc, label: "<b>Scales</b><br> smart scales which will connect to the Liva app."}
-BP@{shape: proc, label: "<b>Blood Pressure monitor</b><br> the user will meassure their blood pressure and enter it into the app."}
+BP@{shape: proc, label: "<b>Blood Pressure monitor</b><br> the user will measure their blood pressure and enter it into the app."}
 MBox@{shape: proc, label: "<b>Meal Boxes</b><br> contains recipes and ingredients for two meals a day."}
 
 %%ID@{shape: proc, label: "<b>NAME</b><br> description ...."}


### PR DESCRIPTION
# Description

Simple fix for typos.

No review needed.

## Checklist

- [x] Ran `just run-all`
